### PR TITLE
Removed 'amazon' ConfigurationProperties from ReadingListController

### DIFF
--- a/ch03/src/main/java/readinglist/ReadingListController.java
+++ b/ch03/src/main/java/readinglist/ReadingListController.java
@@ -14,7 +14,6 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 
 @Controller
 @RequestMapping("/")
-@ConfigurationProperties("amazon")
 public class ReadingListController {
 
 	private ReadingListRepository readingListRepository;


### PR DESCRIPTION
Removed 'amazon' ConfigurationProperties from ReadingListController as 'amazon' ConfigurationProperties is handled via AmazonProperties
